### PR TITLE
Need double-quotes around dependencies in info.rkt

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
                "find-parent-dir"
                "html-lib"
                ["markdown-ng" #:version "0.1"]
-               txexpr
+               "txexpr"
                "racket-index"
                ["rackjure" #:version "0.9"]
                "reprovide-lang"


### PR DESCRIPTION
The package build is currently failing for darwin: 

https://pkgs.racket-lang.org/package/darwin
https://pkg-build.racket-lang.org/server/built/fail/darwin.txt